### PR TITLE
fix incremental build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ ${BIN_TARGET}:${OBJ}
 static:${OBJ}
 	$(CXX) $(OBJ) -o ${BIN_TARGET} $(STATIC_LD_FLAGS)
 
-${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp make_obj_dir
+${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp
+	@mkdir -p $(@D) 
 	$(CXX) -c $< -o $@ $(CXXFLAGS)
 
 .PHONY:clean
@@ -41,12 +42,6 @@ clean:
 	@if test -e $(TARGET) ; \
 	then \
 		rm $(TARGET) ; \
-	fi
-
-make_obj_dir:
-	@if test ! -d $(DIR_OBJ) ; \
-	then \
-		mkdir $(DIR_OBJ) ; \
 	fi
 
 install:

--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -3,7 +3,7 @@
 Sequence::Sequence(){
 }
 
-Sequence::Sequence(string*  seq){
+Sequence::Sequence(string* seq){
     mStr = seq;
 }
 
@@ -49,33 +49,9 @@ string Sequence::reverseComplement(string* origin) {
     return str;
 }
 
-Sequence Sequence::reverseComplement(){
-    string*  str = new string(mStr->length(), 0);
-    int len = mStr->length();
-    for(int c=0;c<mStr->length();c++){
-        char base = (*mStr)[c];
-        switch(base){
-            case 'A':
-            case 'a':
-                (*str)[len-c-1] = 'T';
-                break;
-            case 'T':
-            case 't':
-                (*str)[len-c-1] = 'A';
-                break;
-            case 'C':
-            case 'c':
-                (*str)[len-c-1] = 'G';
-                break;
-            case 'G':
-            case 'g':
-                (*str)[len-c-1] = 'C';
-                break;
-            default:
-                (*str)[len-c-1] = 'N';
-        }
-    }
-    return Sequence(str);
+Sequence Sequence::reverseComplement() {
+    string* reversed = new string(Sequence::reverseComplement(mStr));
+    return Sequence(reversed);
 }
 
 Sequence Sequence::operator~(){


### PR DESCRIPTION
When trying to build this on ubuntu 20.04 in WSL I noticed running `make` would recompile the .cpp code every time.

This change makes running `make` multiple faster since only the files changed will be recompiled.

If you run `make` twice you should see significant build time improvements. This is useful when you change the code, recompile, change the code.
