### PR TITLE
add release workflow to publish binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    env: 
+      GH_TOKEN: ${{ github.token }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-13, macos-15]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+      - uses: lukka/get-cmake@latest
+      - name: Restore from cache the dependencies and generate project files
+        run: |
+          cmake --preset ninja-multi-vcpkg
+
+      - name: Build (Release configuration)
+        run: |
+          cmake --build --preset ninja-vcpkg-release
+
+      # Test the whole project with CTest, again Release configuration only.
+      - name: Test (Release configuration)
+        run: |
+          ctest --preset test-release
+      - name: release
+        run: |
+          set -x
+          TAG_NAME=${{ github.ref }}
+          TAG_NAME=${TAG_NAME#refs/tags/}
+
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          FILE=fastplong_${OS}_$(arch)
+          gh release create $TAG_NAME || :
+          cp builds/ninja-multi-vcpkg/Release/fastplong $FILE
+          gh release upload $TAG_NAME $FILE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
         with:
           submodules: true
 
+      - name: install build dependencies (Ubuntu)
+        run: sudo apt update && sudo apt install -y libisal-dev
+        if: runner.os == 'Linux'
+      - name: install build dependencies (MacOS)
+        run: brew install isa-l
+        if: runner.os == 'macOS'
+
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
       - name: Restore from cache the dependencies and generate project files


### PR DESCRIPTION
This PR adds a new workflow.
When you push a git tag with the format
`v#.#.#` i.e. `v0.2.4` it will trigger this workflow.

When the workflow is run it will build on linux and mac and publish the following binaries.

```bash
fastplong_darwin_arm64
fastplong_darwin_i386
fastplong_linux_x86_64
```

Tested on my own repo and the repo looks like this:
https://github.com/chinwobble/CppCMakeVcpkgTemplate/releases/tag/v0.1.0


Users can download the built binaries using CLI like this
```bash
# specific version
curl https://github.com/OpenGene/fastplong/releases/download/v0.1.0/fastplong_linux_x86_64 --output fastplong
# latest version
curl https://github.com/OpenGene/fastplong/releases/download/latest/fastplong_linux_x86_64 --output fastplong
chmod +x fastplong
./fastplong

sudo install fastplong /usr/local/bin/fastplong
```





