### PR TITLE
Make CMake work on version 3.22

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 8,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 21,


### PR DESCRIPTION
I tested this on Ubuntu-22.04.

This change makes it build with CMake 3.22 which is the latest version on ubuntu-22.04.

```
benney@DESKTOP-DQNT22A:~/s/fastplong$ cmake --version
cmake version 3.22.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
benney@DESKTOP-DQNT22A:~/s/fastplong$ cmak^C
benney@DESKTOP-DQNT22A:~/s/fastplong$ make
cmake --build --preset ninja-vcpkg-release
ninja: no work to do.
```